### PR TITLE
update Toggl API to conform to the new hostnames

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,9 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      max-parallel: 1
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      max-parallel: 1
       matrix:
         node-version: [12.x, 14.x]
 

--- a/readme.md
+++ b/readme.md
@@ -144,10 +144,10 @@ You should don't create these. You can retrieve them using toggl dependency.
 Toggl is using [toggl-api v8](https://github.com/toggl/toggl_api_docs/blob/master/toggl_api.md) and [reports-api v2](https://github.com/toggl/toggl_api_docs/blob/master/reports.md).
 
 Methods (all async):
-* `rawTogglPost(url, object)`: raw post on toggl api. You can skip _"https://www.toggl.com/api/v8"_ on the url.
-* `rawTogglGet(url, queryObject)`: raw get on toggl api. You can skip _"https://www.toggl.com/api/v8"_ on the url. Query object will be converted to query string.
-* `rawReportsPost(url, object, responseType)`: raw get on reports api. You can skip _"https://toggl.com/reports/api/v2"_ on the url. Response type is 'json' by default. If you want to download an object like pdf, you can pass 'arraybuffer' instead.
-* `rawReportsGet(url, queryObject, responseType)`: raw get on reports api. You can skip _"https://toggl.com/reports/api/v2"_ on the url. Query object will be converted to query string. Response type is 'json' by default. If you want to download an object like pdf, you can pass 'arraybuffer' instead.
+* `rawTogglPost(url, object)`: raw post on toggl api. You can skip _"https://api.track.toggl.com/api/v8"_ on the url.
+* `rawTogglGet(url, queryObject)`: raw get on toggl api. You can skip _"https://api.track.toggl.com/api/v8"_ on the url. Query object will be converted to query string.
+* `rawReportsPost(url, object, responseType)`: raw get on reports api. You can skip _"https://api.track.toggl.com/reports/api/v2"_ on the url. Response type is 'json' by default. If you want to download an object like pdf, you can pass 'arraybuffer' instead.
+* `rawReportsGet(url, queryObject, responseType)`: raw get on reports api. You can skip _"https://api.track.toggl.com/reports/api/v2"_ on the url. Query object will be converted to query string. Response type is 'json' by default. If you want to download an object like pdf, you can pass 'arraybuffer' instead.
 * `createTimeEntries(project, task, description, timeSlots)`: create a time entry for each timeslot. You should use project, task and timeslot domain objects.
 * `createTimeEntry(project, task, description, timeSlot)`: create a time entry for single timeslot. You should use project, task and timeslot domain objects.
 * `getTimeEntries(from, to)`: obtain time entries in range. You should pass moments.

--- a/src/reportsApi.ts
+++ b/src/reportsApi.ts
@@ -6,7 +6,7 @@ export class ReportsApi {
 
   constructor (token: string) {
     this.instance = axios.create({
-      baseURL: 'https://www.toggl.com/reports/api/v2/',
+      baseURL: 'https://api.track.toggl.com/reports/api/v2/',
       auth: { username: token, password: 'api_token' },
       headers: { 'Content-type': 'application/json' }
     })

--- a/src/togglApi.ts
+++ b/src/togglApi.ts
@@ -6,7 +6,7 @@ export class TogglApi {
 
   constructor (token: string) {
     this.instance = axios.create({
-      baseURL: 'https://www.toggl.com/api/v8/',
+      baseURL: 'https://api.track.toggl.com/api/v8/',
       auth: { username: token, password: 'api_token' },
       headers: { 'Content-type': 'application/json' }
     })

--- a/test/togglApi.ts
+++ b/test/togglApi.ts
@@ -196,7 +196,7 @@ describe('Toggl Api Integration', () => {
   }
 
   const instance = axios.create({
-    baseURL: 'https://www.toggl.com/api/v8/',
+    baseURL: 'https://api.track.toggl.com/api/v8/',
     auth: {
       username: token,
       password: 'api_token'


### PR DESCRIPTION
While updating the hostname to `api.track.toggl.com`, we also change the CI to use the new LTS node version (`14.x`)